### PR TITLE
Adding macro df_str

### DIFF
--- a/src/dataframe/io.jl
+++ b/src/dataframe/io.jl
@@ -930,6 +930,44 @@ function readtable(pathname::AbstractString;
                      normalizenames = normalizenames)
 end
 
+# Macro to permit expressing a dataframe as a nonstandard string literal
+macro df_str(s, flags...)
+    header = true
+    separator = ','
+    makefactors = false
+    allowcomments = false
+    ignorepadding = true
+    skipblanks = true
+    if !isempty(flags)
+        for f in flags[1]
+            if f=='h'
+                header = false
+            elseif f=='t'
+                separator = '\t'
+            elseif f=='w'
+                separator = ' '
+            elseif f=='f'
+                makefactors = true
+            elseif f=='c'
+                allowcomments = true
+            elseif f=='p'
+                ignorepadding = false
+            elseif f=='b'
+                skipblanks = false
+            else
+                throw(ArgumentError("Unknown df_str flag: $f"))
+            end
+        end
+    end
+    readtable(IOBuffer(s),
+        header=header,
+        separator=separator,
+        makefactors=makefactors,
+        allowcomments=allowcomments,
+        ignorepadding=ignorepadding,
+        skipblanks=skipblanks)
+end
+
 function filldf!(df::DataFrame,
                  rows::Integer,
                  cols::Integer,


### PR DESCRIPTION
I find it handy to have a macro to wrap `readtable` to make it easy to include small-to-medium amounts of data directly alongside code as a nonstandard string literal.  E.g., instead of writing

``` julia
data = DataFrame(
    name=["Alice","Bob","Carol","Eve"],
    age=[36,24,58,49],
    numPetSquid=[3,0,2,7])
```

one can instead write

``` julia
data = df"""
    name,  age, numPetSquid
    Alice,  36,           3
    Bob,    24,           0
    Carol,  58,           2
    Eve,    49,           7"""
```

This seems like a common enough need/convenience that I thought it was worth suggesting as an addition to the package.
